### PR TITLE
Add .vsconfig to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Added by VS2022
+.vsconfig


### PR DESCRIPTION
Sounds like it's ignor-able, and only added by VS2022 installer: https://github.com/github/gitignore/pull/4419